### PR TITLE
Add captive portal detection for iOS, Android, and Windows

### DIFF
--- a/data/hotspot-detect.html
+++ b/data/hotspot-detect.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><meta http-equiv="refresh" content="0;url=/"></head>
+<body>Redirecting to setup...</body>
+</html>

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -511,6 +511,16 @@ void ServerManager_::setupWebServer(IPAddress ip) {
         request->send(LittleFS, CONFIG_JSON, "application/json");
     });
 
+    // Captive portal detection routes.
+    // Android and Chrome OS check /generate_204, Windows checks /connecttest.txt.
+    // iOS/macOS checks /hotspot-detect.html, handled via static file in data/.
+    ws->on("/generate_204", HTTP_GET, [](AsyncWebServerRequest* request) {
+        request->redirect("/");
+    });
+    ws->on("/connecttest.txt", HTTP_GET, [](AsyncWebServerRequest* request) {
+        request->redirect("/");
+    });
+
     addStaticFileHandler();
 
     ws->onNotFound([](AsyncWebServerRequest* request) {


### PR DESCRIPTION
## Summary
- Adds automatic captive portal detection so devices redirect to the setup page on WiFi connect
- Supports iOS (`/hotspot-detect.html`), Android (`/generate_204`), and Windows (`/connecttest.txt`) detection endpoints

## Changes
- `data/hotspot-detect.html`: iOS captive portal response page
- `src/ServerManager.cpp`: Route handlers for all three OS detection endpoints

## Context
When the clock is in AP mode for initial setup, connecting from a phone should automatically open the setup page. Without captive portal detection, users have to manually navigate to 10.0.0.1 — a poor experience for non-technical parents.

## Test plan
- [ ] Connect iPhone to clock AP — verify Safari auto-opens setup page
- [ ] Connect Android phone to clock AP — verify redirect
- [ ] Connect Windows laptop to clock AP — verify redirect
- [ ] Normal WiFi operation unaffected after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)