### PR TITLE
Fix: empty WiFi fields no longer overwrite saved credentials

### DIFF
--- a/data/script.js
+++ b/data/script.js
@@ -102,7 +102,6 @@
             $('#more_sources_wrapper').toggleClass('d-none');
             $(this).text($('#more_sources_wrapper').hasClass('d-none') ? 'More options...' : 'Fewer options');
         });
-
     }
 
     function addAdditionalWifiTypeHandler() {
@@ -512,6 +511,7 @@
     function glucoseDataSourceSwitch() {
         const glucoseSource = $('#glucose_source');
         const value = glucoseSource.val();
+<<<<<<< HEAD
         // Old settings cards are replaced by inline source-fields in the source picker.
         // Keep them permanently hidden.
         $('#nightscout_settings_card').addClass("d-none");
@@ -829,12 +829,16 @@
 
     function createJson() {
         var json = configJson;
-        //WiFi
-        json['ssid'] = $('#ssid').val();
-        if ($('#open_wifi_network').is(':checked')) {
-            json['password'] = "";
-        } else {
-            json['password'] = $('#wifi_password').val();
+        //WiFi — only include credentials if SSID is provided,
+        //so saving other settings doesn't blank out stored WiFi config
+        var ssidVal = ($('#ssid').val() || "").trim();
+        if (ssidVal.length > 0) {
+            json['ssid'] = ssidVal;
+            if ($('#open_wifi_network').is(':checked')) {
+                json['password'] = "";
+            } else {
+                json['password'] = $('#wifi_password').val();
+            }
         }
 
         //Glucose source


### PR DESCRIPTION
## Summary

- In `data/script.js`, the `createJson()` function now only includes `ssid` and `password` keys in the save payload when the SSID field has a non-empty value.
- Previously, opening the old settings page and clicking save would POST empty strings for WiFi credentials, overwriting the stored config and forcing AP mode on reboot.

Fixes #7

## Test plan

- [ ] Open the old settings page (`/index.html`) on a clock with saved WiFi credentials
- [ ] Leave SSID and password fields empty, change an unrelated setting, click save
- [ ] Verify the clock does NOT reboot into AP mode (WiFi credentials preserved)
- [ ] Fill in new SSID/password, save, verify new credentials are applied
- [ ] Check "Open WiFi network" with a valid SSID, save, verify password is stored as empty string
- [ ] PlatformIO build passes (`pio run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)