### PR TITLE
Big text face: replace trend arrow with vertical line indicator

### DIFF
--- a/data_dev/face_simulator.html
+++ b/data_dev/face_simulator.html
@@ -211,12 +211,13 @@ const faces=[
     drawTrendLine(31,trend(),color);
     drawTimerBlocks(18,14,C.green);
 }},
-{name:'Big text',desc:'Large BG number across full display',draw(){
+{name:'Big text',desc:'Large BG number with trend indicator',draw(){
     const v=bg(),color=getBgColor(v);
     const s=String(v);
     const totalW=s.length*6-1;
     const startX=Math.floor((32-totalW)/2);
     drawText(s,startX,7,color,true);
+    drawTrendLine(31,trend(),color);
 }},
 {name:'Value and diff',desc:'BG reading with change since last reading',draw(){
     const v=bg(),color=getBgColor(v);

--- a/src/BGDisplayFaceBigText.cpp
+++ b/src/BGDisplayFaceBigText.cpp
@@ -7,7 +7,8 @@ void BGDisplayFaceBigText::showReadings(
     const std::list<GlucoseReading>& readings, bool dataIsOld) const {
     showReading(readings.back(), 0, 7, TEXT_ALIGNMENT::LEFT, FONT_TYPE::LARGE, dataIsOld);
 
-    // show arrow in the right part of the screen
-    showTrendArrow(readings.back(), MATRIX_WIDTH - 5, 1, dataIsOld);
-    DisplayManager.update();
+    // show trend as a vertical line on the rightmost column
+    // (the 5x5 arrow bitmap overlaps the 7-row tall big font, so use
+    // the single-column indicator instead — same pattern as Clock face)
+    showTrendVerticalLine(MATRIX_WIDTH - 1, readings.back().trend, dataIsOld);
 }


### PR DESCRIPTION
## Summary
- Replace the 5x5 bitmap trend arrow on the Big Text face with the single-column vertical line indicator used by Clock and GraphAndBG faces
- The bitmap arrow overlapped the 7-row tall large font on the 32x8 display, making both unreadable
- The vertical line indicator fits cleanly on the rightmost column (x=31) without conflicting with the BG number
- Update the face simulator (`data_dev/face_simulator.html`) to render the trend indicator on the Big Text face

## Test plan
- [ ] Build passes (`pio run`)
- [ ] Flash to device and verify Big Text face shows colored trend dots on rightmost column
- [ ] Verify trend directions render correctly: flat, rising, falling, fast-rising, fast-falling
- [ ] Verify old-data mode grays out or hides the trend indicator
- [ ] Open `data_dev/face_simulator.html` and confirm Big Text face now shows trend line

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)