### PR TITLE
Add face rotation selection for auto-rotate

### DIFF
--- a/data/config_initial.json
+++ b/data/config_initial.json
@@ -58,6 +58,7 @@
     "web_auth_password": "",
     "face_auto_rotate": true,
     "face_rotate_interval_sec": 15,
+    "face_rotation_enabled_faces": "0,1,2,3,4,5,6,7",
     "setup_zip": "",
     "weather_lat": 0,
     "weather_lon": 0

--- a/data/index.html
+++ b/data/index.html
@@ -983,6 +983,46 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="row mt-3">
+                            <div class="col-12">
+                                <label class="form-label">Faces included in auto-rotate</label>
+                                <div class="d-flex flex-wrap gap-3">
+                                    <div class="form-check">
+                                        <input class="form-check-input face-rotate-check" type="checkbox" value="0" id="face_rotate_0" checked>
+                                        <label class="form-check-label" for="face_rotate_0">Simple</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input face-rotate-check" type="checkbox" value="1" id="face_rotate_1" checked>
+                                        <label class="form-check-label" for="face_rotate_1">Full graph</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input face-rotate-check" type="checkbox" value="2" id="face_rotate_2" checked>
+                                        <label class="form-check-label" for="face_rotate_2">Graph and BG</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input face-rotate-check" type="checkbox" value="3" id="face_rotate_3" checked>
+                                        <label class="form-check-label" for="face_rotate_3">Big text</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input face-rotate-check" type="checkbox" value="4" id="face_rotate_4" checked>
+                                        <label class="form-check-label" for="face_rotate_4">Value and diff</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input face-rotate-check" type="checkbox" value="5" id="face_rotate_5" checked>
+                                        <label class="form-check-label" for="face_rotate_5">Clock and value</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input face-rotate-check" type="checkbox" value="6" id="face_rotate_6" checked>
+                                        <label class="form-check-label" for="face_rotate_6">Room temp</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input face-rotate-check" type="checkbox" value="7" id="face_rotate_7" checked>
+                                        <label class="form-check-label" for="face_rotate_7">Weather</label>
+                                    </div>
+                                </div>
+                                <small class="text-muted">Uncheck faces you don't want in the auto-rotate cycle.</small>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <br />

--- a/data/script.js
+++ b/data/script.js
@@ -911,6 +911,14 @@
         json['brightness_mode'] = brightnessMode;
         json['brightness_level'] = brightness;
         json['default_face'] = parseInt($('#default_clock_face').val());
+
+        // Face rotation enabled faces
+        var enabledFaces = [];
+        $('.face-rotate-check:checked').each(function() {
+            enabledFaces.push($(this).val());
+        });
+        json['face_rotation_enabled_faces'] = enabledFaces.join(',');
+
         json['tz_libc'] = $('#clock_timezone').val();
         json['tz'] = $('#clock_timezone option:selected').text();
         json['time_format'] = $('#time_format').val();
@@ -1247,6 +1255,13 @@
         // Device settings
         $('#brightness_level').val(json['brightness_level']);
         $('#default_clock_face').val(json['default_face']);
+
+        // Face rotation enabled faces
+        var enabledFacesStr = json['face_rotation_enabled_faces'] || '0,1,2,3,4,5,6,7';
+        var enabledFaces = enabledFacesStr.split(',');
+        $('.face-rotate-check').each(function() {
+            $(this).prop('checked', enabledFaces.indexOf($(this).val()) !== -1);
+        });
 
         $('#time_format').val(json['time_format']);
 

--- a/data/script.js
+++ b/data/script.js
@@ -917,6 +917,11 @@
         $('.face-rotate-check:checked').each(function() {
             enabledFaces.push($(this).val());
         });
+        if (enabledFaces.length === 0) {
+            alert('At least one clock face must be enabled. Defaulting to face 0.');
+            enabledFaces.push('0');
+            $('.face-rotate-check').filter('[value="0"]').prop('checked', true);
+        }
         json['face_rotation_enabled_faces'] = enabledFaces.join(',');
 
         json['tz_libc'] = $('#clock_timezone').val();

--- a/src/BGDisplayManager.cpp
+++ b/src/BGDisplayManager.cpp
@@ -76,6 +76,51 @@ void BGDisplayManager_::setFace(int id) {
     }
 }
 
+std::vector<int> BGDisplayManager_::parseEnabledFaces(const String& csv) {
+    std::vector<int> enabled;
+    int start = 0;
+    int commaIndex;
+    while ((commaIndex = csv.indexOf(',', start)) != -1) {
+        int val = csv.substring(start, commaIndex).toInt();
+        if (val >= 0 && val < (int)faces.size()) {
+            enabled.push_back(val);
+        }
+        start = commaIndex + 1;
+    }
+    // last (or only) token
+    if (start < (int)csv.length()) {
+        int val = csv.substring(start).toInt();
+        if (val >= 0 && val < (int)faces.size()) {
+            enabled.push_back(val);
+        }
+    }
+    return enabled;
+}
+
+bool BGDisplayManager_::isFaceEnabled(int faceIndex) {
+    auto enabled = parseEnabledFaces(SettingsManager.settings.face_rotation_enabled_faces);
+    for (int idx : enabled) {
+        if (idx == faceIndex) return true;
+    }
+    return false;
+}
+
+int BGDisplayManager_::getNextEnabledFace(int currentIndex) {
+    auto enabled = parseEnabledFaces(SettingsManager.settings.face_rotation_enabled_faces);
+    if (enabled.empty()) {
+        // Fallback: if nothing enabled, just go to next face
+        return (currentIndex + 1) % faces.size();
+    }
+    // Find current face in enabled list, then pick next
+    for (size_t i = 0; i < enabled.size(); i++) {
+        if (enabled[i] == currentIndex) {
+            return enabled[(i + 1) % enabled.size()];
+        }
+    }
+    // Current face not in enabled list, jump to first enabled face
+    return enabled[0];
+}
+
 void BGDisplayManager_::tick() {
     // Auto-rotate faces on a timer
     if (SettingsManager.settings.face_auto_rotate) {
@@ -83,7 +128,7 @@ void BGDisplayManager_::tick() {
         unsigned long intervalMs = (unsigned long)SettingsManager.settings.face_rotate_interval_sec * 1000UL;
         if (now - lastFaceRotateMs >= intervalMs) {
             lastFaceRotateMs = now;
-            int nextFace = (currentFaceIndex + 1) % faces.size();
+            int nextFace = getNextEnabledFace(currentFaceIndex);
             setFace(nextFace);
             return;  // setFace calls maybeRrefreshScreen directly
         }

--- a/src/BGDisplayManager.cpp
+++ b/src/BGDisplayManager.cpp
@@ -58,6 +58,8 @@ void BGDisplayManager_::setup() {
     }
 
     currentFace = (faces[currentFaceIndex]);
+
+    refreshCachedEnabledFaces();
 }
 
 std::map<int, String> BGDisplayManager_::getFaces() { return facesNames; }
@@ -81,44 +83,50 @@ std::vector<int> BGDisplayManager_::parseEnabledFaces(const String& csv) {
     int start = 0;
     int commaIndex;
     while ((commaIndex = csv.indexOf(',', start)) != -1) {
-        int val = csv.substring(start, commaIndex).toInt();
-        if (val >= 0 && val < (int)faces.size()) {
+        String token = csv.substring(start, commaIndex);
+        token.trim();
+        int val = token.toInt();
+        if (token.length() > 0 && (val != 0 || token == "0") && val >= 0 && val < (int)faces.size()) {
             enabled.push_back(val);
         }
         start = commaIndex + 1;
     }
     // last (or only) token
     if (start < (int)csv.length()) {
-        int val = csv.substring(start).toInt();
-        if (val >= 0 && val < (int)faces.size()) {
+        String token = csv.substring(start);
+        token.trim();
+        int val = token.toInt();
+        if (token.length() > 0 && (val != 0 || token == "0") && val >= 0 && val < (int)faces.size()) {
             enabled.push_back(val);
         }
     }
     return enabled;
 }
 
+void BGDisplayManager_::refreshCachedEnabledFaces() {
+    cachedEnabledFaces = parseEnabledFaces(SettingsManager.settings.face_rotation_enabled_faces);
+}
+
 bool BGDisplayManager_::isFaceEnabled(int faceIndex) {
-    auto enabled = parseEnabledFaces(SettingsManager.settings.face_rotation_enabled_faces);
-    for (int idx : enabled) {
+    for (int idx : cachedEnabledFaces) {
         if (idx == faceIndex) return true;
     }
     return false;
 }
 
 int BGDisplayManager_::getNextEnabledFace(int currentIndex) {
-    auto enabled = parseEnabledFaces(SettingsManager.settings.face_rotation_enabled_faces);
-    if (enabled.empty()) {
+    if (cachedEnabledFaces.empty()) {
         // Fallback: if nothing enabled, just go to next face
         return (currentIndex + 1) % faces.size();
     }
     // Find current face in enabled list, then pick next
-    for (size_t i = 0; i < enabled.size(); i++) {
-        if (enabled[i] == currentIndex) {
-            return enabled[(i + 1) % enabled.size()];
+    for (size_t i = 0; i < cachedEnabledFaces.size(); i++) {
+        if (cachedEnabledFaces[i] == currentIndex) {
+            return cachedEnabledFaces[(i + 1) % cachedEnabledFaces.size()];
         }
     }
     // Current face not in enabled list, jump to first enabled face
-    return enabled[0];
+    return cachedEnabledFaces[0];
 }
 
 void BGDisplayManager_::tick() {

--- a/src/BGDisplayManager.h
+++ b/src/BGDisplayManager.h
@@ -77,6 +77,11 @@ private:
     int currentFaceIndex;
     GlucoseIntervals glucoseIntervals;
     std::map<int, String> facesNames;
+    std::vector<int> cachedEnabledFaces;
+
+    int getNextEnabledFace(int currentIndex);
+    bool isFaceEnabled(int faceIndex);
+    std::vector<int> parseEnabledFaces(const String& csv);
 
 public:
     static BGDisplayManager_& getInstance();
@@ -95,10 +100,7 @@ public:
     static void drawTimerBlocks(GlucoseReading lastReading, int width, int xPosition, int yPosition);
 
     void resetAutoRotateTimer();
-
-    int getNextEnabledFace(int currentIndex);
-    bool isFaceEnabled(int faceIndex);
-    std::vector<int> parseEnabledFaces(const String& csv);
+    void refreshCachedEnabledFaces();
 
 private:
     unsigned long long lastRefreshEpoch;

--- a/src/BGDisplayManager.h
+++ b/src/BGDisplayManager.h
@@ -96,6 +96,10 @@ public:
 
     void resetAutoRotateTimer();
 
+    int getNextEnabledFace(int currentIndex);
+    bool isFaceEnabled(int faceIndex);
+    std::vector<int> parseEnabledFaces(const String& csv);
+
 private:
     unsigned long long lastRefreshEpoch;
     unsigned long lastFaceRotateMs = 0;

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -7,6 +7,7 @@
 #include <WiFi.h>
 #include <esp_system.h>
 
+#include "BGDisplayManager.h"
 #include "BGSourceManager.h"
 #include "DisplayManager.h"
 #include "PeripheryManager.h"
@@ -391,6 +392,7 @@ void ServerManager_::setupWebServer(IPAddress ip) {
             }
             auto&& data = json.as<JsonObject>();
             if (SettingsManager.trySaveJsonAsSettings(data)) {
+                bgDisplayManager.refreshCachedEnabledFaces();
                 request->send(200, "application/json", "{\"status\": \"ok\"}");
             } else {
                 request->send(200, "application/json", "{\"status\": \"Settings save error\"}");

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -61,6 +61,7 @@ public:
     String web_auth_password;
     bool face_auto_rotate = true;
     int face_rotate_interval_sec = 15;
+    String face_rotation_enabled_faces = "0,1,2,3,4,5,6,7";
     String setup_zip;
     float weather_lat = 0;
     float weather_lon = 0;

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -214,6 +214,11 @@ bool SettingsManager_::loadSettingsFromFile() {
     if (settings.face_rotate_interval_sec < 5 || settings.face_rotate_interval_sec > 120) {
         settings.face_rotate_interval_sec = 15;  // default 15 seconds
     }
+    if ((*doc)["face_rotation_enabled_faces"].is<const char*>() && strlen((*doc)["face_rotation_enabled_faces"].as<const char*>()) > 0) {
+        settings.face_rotation_enabled_faces = (*doc)["face_rotation_enabled_faces"].as<String>();
+    } else {
+        settings.face_rotation_enabled_faces = "0,1,2,3,4,5,6,7";  // all faces enabled by default
+    }
 
     // Location (from zip code geocoding)
     settings.setup_zip = (*doc)["setup_zip"].as<String>();
@@ -345,6 +350,7 @@ bool SettingsManager_::saveSettingsToFile() {
     // Face auto-rotate
     (*doc)["face_auto_rotate"] = settings.face_auto_rotate;
     (*doc)["face_rotate_interval_sec"] = settings.face_rotate_interval_sec;
+    (*doc)["face_rotation_enabled_faces"] = settings.face_rotation_enabled_faces;
 
     // Location (from zip code geocoding)
     (*doc)["setup_zip"] = settings.setup_zip;


### PR DESCRIPTION
## Summary

- Adds `face_rotation_enabled_faces` setting (comma-separated face indices, e.g. `"0,1,3,5"`) to control which display faces are included in the auto-rotate cycle
- All 8 faces enabled by default (`"0,1,2,3,4,5,6,7"`) for full backward compatibility
- Auto-rotate `tick()` now calls `getNextEnabledFace()` which skips unchecked faces
- Web UI includes checkboxes under "Device settings" for each face so users can toggle them without editing JSON
- Setting persists through config.json load/save cycle

## Files changed

| File | Change |
|------|--------|
| `src/Settings.h` | New `face_rotation_enabled_faces` field |
| `src/SettingsManager.cpp` | Load/save the new field with fallback default |
| `src/BGDisplayManager.h` | `parseEnabledFaces()`, `isFaceEnabled()`, `getNextEnabledFace()` |
| `src/BGDisplayManager.cpp` | Rotation logic uses enabled face list; helper methods |
| `data/config_initial.json` | Default value for new setting |
| `data/index.html` | Checkbox UI for face selection |
| `data/script.js` | Save/load checkboxes to/from config JSON |

## Test plan

- [ ] Flash firmware, verify all 8 faces rotate by default (backward compat)
- [ ] Uncheck some faces in web UI, save, verify only checked faces rotate
- [ ] Verify manual face switching (buttons) still works for all faces
- [ ] Verify config.json persists the setting across reboots
- [ ] Verify empty/missing `face_rotation_enabled_faces` falls back to all faces

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)