### PR TITLE
Add device PIN to captive portal setup

### DIFF
--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -726,6 +726,18 @@ void ServerManager_::setupWebServer(IPAddress ip) {
                 "<input type=\"password\" name=\"api_secret\"></div></div>"
                 "</div></div>";
 
+        // Optional device PIN — enables web authentication to protect settings
+        html += "<div class=\"section\">"
+                "<p class=\"sl\">Device PIN <span style=\"text-transform:none;color:#555\">(optional)</span></p>"
+                "<p style=\"font-size:13px;color:#888;margin-bottom:12px;line-height:1.4\">"
+                "Set a 4&ndash;6 digit PIN to protect the settings page from unauthorized access.</p>"
+                "<div class=\"f\">"
+                "<label class=\"fl\" for=\"device_pin\">PIN</label>"
+                "<input type=\"password\" id=\"device_pin\" name=\"device_pin\" "
+                "inputmode=\"numeric\" pattern=\"[0-9]{4,6}\" maxlength=\"6\" "
+                "autocomplete=\"off\" placeholder=\"4-6 digits\">"
+                "</div></div>";
+
         html += "<button type=\"submit\">Connect &amp; start</button>"
                 "</form></body></html>";
 
@@ -807,6 +819,15 @@ void ServerManager_::setupWebServer(IPAddress ip) {
         // Zip code (triggers timezone + weather location geocoding after WiFi connects)
         if (request->hasParam("zip", true)) {
             SettingsManager.settings.setup_zip = request->getParam("zip", true)->value();
+        }
+
+        // Device PIN — enable web authentication if a valid PIN was provided
+        if (request->hasParam("device_pin", true)) {
+            String pin = request->getParam("device_pin", true)->value();
+            if (pin.length() >= 4 && pin.length() <= 6) {
+                SettingsManager.settings.web_auth_enable = true;
+                SettingsManager.settings.web_auth_password = pin;
+            }
         }
 
         if (!SettingsManager.saveSettingsToFile()) {


### PR DESCRIPTION
## Summary
- Adds an optional 4-6 digit "Device PIN" field to the captive portal setup form
- When a PIN is provided, automatically sets `web_auth_enable = true` and `web_auth_password` to the PIN value, activating the existing cookie-based auth system
- Credential fields on the full settings page (`data/index.html`) already use `type="password"` -- no changes needed there

## How it works
The PIN field appears as a new section at the bottom of the captive portal, before the submit button. It uses `inputmode="numeric"` for a number pad on mobile and validates 4-6 digits via HTML pattern. If left blank, auth stays disabled (backward compatible).

The existing auth system in `ServerManager.cpp` (`isWebAuthEnabled`, `isRequestAuthenticated`, cookie-based token) handles everything from there -- no new auth code needed.

## Test plan
- [ ] Flash firmware, go through captive portal setup **without** a PIN -- verify settings page remains unprotected (backward compat)
- [ ] Flash firmware, set a 4-digit PIN during setup -- verify settings page prompts for password
- [ ] Verify entering the correct PIN grants access, wrong PIN is rejected
- [ ] Verify all credential fields on settings page show dots, not plaintext

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)