### PR TITLE
Set up web flasher on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,112 @@
+name: Build firmware and deploy web flasher
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "v-*"
+
+jobs:
+  build:
+    name: Build firmware
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build release firmware
+        run: pio run --environment ulanzi
+      - name: Build release filesystem image
+        run: pio run --target buildfs --environment ulanzi
+      - name: Collect release artifacts
+        run: |
+          mkdir artifacts
+          cp .pio/build/ulanzi/bootloader.bin artifacts/
+          cp .pio/build/ulanzi/partitions.bin artifacts/
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin artifacts/
+          cp .pio/build/ulanzi/firmware.bin artifacts/
+          cp .pio/build/ulanzi/littlefs.bin artifacts/
+
+      - name: Enable debug flags in platformio.ini
+        run: |
+          sed -i 's/#    -DDEBUG_BG_SOURCE/    -DDEBUG_BG_SOURCE/' platformio.ini
+          sed -i 's/#    -DDEBUG_DISPLAY/    -DDEBUG_DISPLAY/' platformio.ini
+          sed -i 's/#    -DDEBUG_BRIGHTNESS/    -DDEBUG_BRIGHTNESS/' platformio.ini
+          sed -i 's/#    -DDEBUG_ALARMS/    -DDEBUG_ALARMS/' platformio.ini
+          sed -i 's/#    -DDEBUG_MEMORY/    -DDEBUG_MEMORY/' platformio.ini
+      - name: Build debug firmware
+        run: pio run --environment ulanzi_debug
+      - name: Build debug filesystem image
+        run: pio run --target buildfs --environment ulanzi_debug
+      - name: Collect debug artifacts
+        run: |
+          mkdir artifacts-debug
+          cp .pio/build/ulanzi_debug/bootloader.bin artifacts-debug/
+          cp .pio/build/ulanzi_debug/partitions.bin artifacts-debug/
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin artifacts-debug/
+          cp .pio/build/ulanzi_debug/firmware.bin artifacts-debug/
+          cp .pio/build/ulanzi_debug/littlefs.bin artifacts-debug/
+
+      - name: Package build artifacts
+        run: |
+          mkdir -p combined/release combined/debug
+          cp artifacts/*.bin combined/release/
+          cp artifacts-debug/*.bin combined/debug/
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware
+          path: combined/
+          retention-days: 1
+
+  deploy:
+    name: Deploy web flasher to GitHub Pages
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware
+          path: firmware
+      - name: Assemble site
+        run: |
+          mkdir -p www/artifacts www/debug/artifacts
+          cp firmware/release/*.bin www/artifacts/
+          cp firmware/debug/*.bin www/debug/artifacts/
+          cp www/debug/manifest-debug.json www/debug/manifest.json
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "www"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/www/debug/index.html
+++ b/www/debug/index.html
@@ -1,141 +1,220 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />
-    <title>Nightscout clock web flasher - Debug Build</title>
-    <meta name="description" content="Easily allow users to install Nightscout clock firmware on the web." />
-    <meta name="viewport" content="width=device-width" />
-    <meta name="color-scheme" content="dark light" />
+    <title>Nightscout Clock Installer - Debug Build</title>
+    <meta name="description"
+        content="Flash the debug build of Nightscout Clock firmware to your Ulanzi TC001." />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
     <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
         body {
             font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI",
                 Roboto, Ubuntu, sans-serif;
-            padding: 0;
-            margin: 0;
-            line-height: 1.4;
+            background-color: #1a1a2e;
+            color: #e0e0e0;
+            line-height: 1.6;
+            min-height: 100vh;
         }
 
-        .content {
-            max-width: 600px;
+        .container {
+            max-width: 640px;
             margin: 0 auto;
-            padding: 12px;
+            padding: 40px 20px;
         }
 
-        h2 {
-            margin-top: 2em;
+        .hero {
+            text-align: center;
+            margin-bottom: 40px;
         }
 
-        h3 {
-            margin-top: 1.5em;
+        .hero h1 {
+            font-size: 2em;
+            font-weight: 700;
+            color: #ffffff;
+            margin-bottom: 8px;
+        }
+
+        .hero .subtitle {
+            font-size: 1.1em;
+            color: #a0a0b8;
+        }
+
+        .card {
+            background: #16213e;
+            border: 1px solid #2a2a4a;
+            border-radius: 12px;
+            padding: 32px;
+            margin-bottom: 24px;
+        }
+
+        .card h2 {
+            font-size: 1.2em;
+            color: #ffffff;
+            margin-bottom: 16px;
+        }
+
+        .steps {
+            list-style: none;
+            counter-reset: steps;
+        }
+
+        .steps li {
+            counter-increment: steps;
+            padding: 10px 0 10px 48px;
+            position: relative;
+            border-bottom: 1px solid #2a2a4a;
+        }
+
+        .steps li:last-child {
+            border-bottom: none;
+        }
+
+        .steps li::before {
+            content: counter(steps);
+            position: absolute;
+            left: 0;
+            top: 10px;
+            width: 32px;
+            height: 32px;
+            background: #0f3460;
+            color: #53a8b6;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            font-size: 0.9em;
+        }
+
+        .install-box {
+            text-align: center;
+            padding: 32px 0;
+        }
+
+        .install-box p {
+            margin-bottom: 20px;
+            color: #a0a0b8;
+            font-size: 0.95em;
         }
 
         a {
-            color: #03a9f4;
+            color: #53a8b6;
+            text-decoration: none;
         }
 
-        .invisible {
-            visibility: hidden;
-        }
-
-        .hidden {
-            display: none;
-        }
-
-        esp-web-install-button[install-unsupported] {
-            visibility: inherit;
-        }
-
-        .content pre {
-            max-width: 100%;
-            overflow-y: scroll;
+        a:hover {
+            text-decoration: underline;
         }
 
         .footer {
-            margin-top: 24px;
-            border-top: 1px solid #ccc;
-            padding-top: 24px;
             text-align: center;
+            margin-top: 40px;
+            padding-top: 24px;
+            border-top: 1px solid #2a2a4a;
+            font-size: 0.85em;
+            color: #666;
         }
 
-        .footer .initiative {
-            font-style: italic;
-            margin-top: 16px;
-        }
-
-        table {
-            border-spacing: 0;
-        }
-
-        td {
-            padding: 8px;
-            border-bottom: 1px solid #ccc;
-        }
-
-        .radios li {
-            list-style: none;
-            line-height: 2em;
+        .footer a {
+            color: #888;
         }
 
         .debug-banner {
-            background-color: #ff9800;
-            color: #000;
-            padding: 12px;
-            margin-bottom: 20px;
-            border-radius: 4px;
-            font-weight: bold;
+            background: #4a2800;
+            border: 1px solid #7a4a00;
+            border-radius: 8px;
+            padding: 14px 20px;
             text-align: center;
+            margin-bottom: 24px;
+            color: #ffb347;
+            font-weight: 600;
         }
 
-        @media (prefers-color-scheme: dark) {
-            body {
-                background-color: #333;
-                color: #fff;
-            }
-
-            a {
-                color: #58a6ff;
-            }
-
-            .debug-banner {
-                background-color: #ff6f00;
-                color: #fff;
-            }
+        .release-link {
+            text-align: center;
+            margin-top: 16px;
+            font-size: 0.85em;
         }
     </style>
-    <script type="module" src="https://unpkg.com/esp-web-tools@8.0.1/dist/web/install-button.js?module"></script>
+    <script type="module"
+        src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"></script>
 </head>
 
 <body>
-    <div class="content">
-        <div class="debug-banner">⚠️ DEBUG BUILD - For testing and troubleshooting only</div>
-        <h1>Nightscout clock installer - Debug Build</h1>
-        <p>
-            This is a <strong>debug build</strong> of the <a
-                href="https://github.com/ktomy/nightscout-clock/">Nightscout Clock</a> project.
-            It allows you to transform an Ulanzi TC001 programmable clock into a device showing blood sugar values
-            through <a href="https://github.com/nightscout/cgm-remote-monitor">Nightscout</a>.
-        </p>
-        <p>
-            <strong>⚠️ Warning:</strong> This debug build includes additional logging and debugging features.
-            Use this version only for testing and troubleshooting. For production use, please use the
-            <a href="https://ktomy.github.io/nightscout-clock/">release build</a>.
-        </p>
-        <p>
-            Here are the steps to install the firmware
-        </p>
-        <ul>
-            <li>Buy Ulanzi TC001 from <a
-                    href="https://www.ulanzi.com/products/ulanzi-pixel-smart-clock-2882?aff=1191">here</a>)</li>
-            <li>Turn on the device by pressing &lt; and &gt; buttons for 3 seconds</li>
-            <li>Connect the device to your computer using USB cable</li>
-            <li>Click the <b>CONNECT</b> button below</li>
-            <li>Follow the instructions</li>
-        </ul>
-        <p class="button-row" align="center">
-            <esp-web-install-button manifest="./manifest.json"></esp-web-install-button>
-        </p>
+    <div class="container">
+        <div class="hero">
+            <h1>Nightscout Clock</h1>
+            <p class="subtitle">Debug Build - For testing and troubleshooting</p>
+        </div>
 
+        <div class="debug-banner">
+            This is a debug build with extra logging enabled. For normal use,
+            install the <a href="../">release build</a> instead.
+        </div>
+
+        <div class="card">
+            <h2>Install debug firmware</h2>
+            <ol class="steps">
+                <li>Power on the Ulanzi TC001 by holding the <strong>&lt;</strong> and
+                    <strong>&gt;</strong> buttons for 3 seconds</li>
+                <li>Connect it to this computer with a USB-C cable</li>
+                <li>Click the <strong>Install</strong> button below and select the serial port</li>
+            </ol>
+            <div class="install-box">
+                <p>Ready? Plug in your clock and click Install.</p>
+                <esp-web-install-button manifest="./manifest.json">
+                    <button slot="activate" style="
+                        background: #c97b2a;
+                        color: #fff;
+                        border: none;
+                        padding: 14px 40px;
+                        border-radius: 8px;
+                        font-size: 1.1em;
+                        font-weight: 600;
+                        cursor: pointer;
+                        transition: background 0.2s;
+                    ">Install Debug Build</button>
+                    <span slot="unsupported">
+                        <div style="
+                            padding: 16px;
+                            background: #3a1a1a;
+                            border: 1px solid #6a2a2a;
+                            border-radius: 8px;
+                            color: #e88;
+                            text-align: center;
+                            margin-top: 12px;
+                        ">
+                            Your browser does not support Web Serial.<br />
+                            Please open this page in <strong>Google Chrome</strong> or
+                            <strong>Microsoft Edge</strong> on a desktop computer.
+                        </div>
+                    </span>
+                </esp-web-install-button>
+            </div>
+        </div>
+
+        <div class="release-link">
+            <a href="../">Back to release build</a>
+        </div>
+
+        <div class="footer">
+            <p>
+                <a href="https://github.com/miqcie/nightscout-clock" target="_blank"
+                    rel="noopener">Source on GitHub</a>
+                &middot;
+                Powered by <a href="https://esphome.github.io/esp-web-tools/" target="_blank"
+                    rel="noopener">ESP Web Tools</a>
+            </p>
+        </div>
+    </div>
 </body>
 
 </html>

--- a/www/debug/manifest-debug.json
+++ b/www/debug/manifest-debug.json
@@ -1,28 +1,28 @@
 {
-  "name": "Nightscout clock (Debug)",
-  "version": "0.28.0-debug",
+  "name": "Nightscout Clock (Debug)",
+  "version": "1.0.0-debug",
   "builds": [
     {
       "chipFamily": "ESP32",
       "parts": [
         {
-          "path": "https://ktomy.github.io/nightscout-clock/debug/artifacts/bootloader.bin",
+          "path": "./artifacts/bootloader.bin",
           "offset": 4096
         },
         {
-          "path": "https://ktomy.github.io/nightscout-clock/debug/artifacts/partitions.bin",
+          "path": "./artifacts/partitions.bin",
           "offset": 32768
         },
         {
-          "path": "https://ktomy.github.io/nightscout-clock/debug/artifacts/boot_app0.bin",
+          "path": "./artifacts/boot_app0.bin",
           "offset": 57344
         },
         {
-          "path": "https://ktomy.github.io/nightscout-clock/debug/artifacts/firmware.bin",
+          "path": "./artifacts/firmware.bin",
           "offset": 65536
         },
         {
-          "path": "https://ktomy.github.io/nightscout-clock/debug/artifacts/littlefs.bin",
+          "path": "./artifacts/littlefs.bin",
           "offset": 2162688
         }
       ]

--- a/www/index.html
+++ b/www/index.html
@@ -1,119 +1,300 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />
-    <title>Nightscout clock web flasher</title>
-    <meta name="description" content="Easily allow users to install Nightscout clock firmware on the web." />
-    <meta name="viewport" content="width=device-width" />
-    <meta name="color-scheme" content="dark light" />
+    <title>Nightscout Clock Installer</title>
+    <meta name="description"
+        content="Flash the Nightscout Clock firmware to your Ulanzi TC001 directly from your browser." />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
     <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
         body {
             font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI",
                 Roboto, Ubuntu, sans-serif;
-            padding: 0;
-            margin: 0;
-            line-height: 1.4;
+            background-color: #1a1a2e;
+            color: #e0e0e0;
+            line-height: 1.6;
+            min-height: 100vh;
         }
 
-        .content {
-            max-width: 600px;
+        .container {
+            max-width: 640px;
             margin: 0 auto;
-            padding: 12px;
+            padding: 40px 20px;
         }
 
-        h2 {
-            margin-top: 2em;
+        .hero {
+            text-align: center;
+            margin-bottom: 40px;
         }
 
-        h3 {
-            margin-top: 1.5em;
+        .hero h1 {
+            font-size: 2em;
+            font-weight: 700;
+            color: #ffffff;
+            margin-bottom: 8px;
         }
 
-        a {
-            color: #03a9f4;
+        .hero .subtitle {
+            font-size: 1.1em;
+            color: #a0a0b8;
         }
 
-        .invisible {
-            visibility: hidden;
+        .card {
+            background: #16213e;
+            border: 1px solid #2a2a4a;
+            border-radius: 12px;
+            padding: 32px;
+            margin-bottom: 24px;
         }
 
-        .hidden {
+        .card h2 {
+            font-size: 1.2em;
+            color: #ffffff;
+            margin-bottom: 16px;
+        }
+
+        .steps {
+            list-style: none;
+            counter-reset: steps;
+        }
+
+        .steps li {
+            counter-increment: steps;
+            padding: 10px 0 10px 48px;
+            position: relative;
+            border-bottom: 1px solid #2a2a4a;
+        }
+
+        .steps li:last-child {
+            border-bottom: none;
+        }
+
+        .steps li::before {
+            content: counter(steps);
+            position: absolute;
+            left: 0;
+            top: 10px;
+            width: 32px;
+            height: 32px;
+            background: #0f3460;
+            color: #53a8b6;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            font-size: 0.9em;
+        }
+
+        .install-box {
+            text-align: center;
+            padding: 32px 0;
+        }
+
+        .install-box p {
+            margin-bottom: 20px;
+            color: #a0a0b8;
+            font-size: 0.95em;
+        }
+
+        esp-web-install-button {
+            --esp-tools-button-color: #53a8b6;
+            --esp-tools-button-text-color: #fff;
+        }
+
+        .not-supported {
             display: none;
         }
 
-        esp-web-install-button[install-unsupported] {
-            visibility: inherit;
-        }
-
-        .content pre {
-            max-width: 100%;
-            overflow-y: scroll;
-        }
-
-        .footer {
-            margin-top: 24px;
-            border-top: 1px solid #ccc;
-            padding-top: 24px;
+        esp-web-install-button[install-unsupported] + .not-supported {
+            display: block;
+            padding: 16px;
+            background: #3a1a1a;
+            border: 1px solid #6a2a2a;
+            border-radius: 8px;
+            color: #e88;
             text-align: center;
+            margin-top: 12px;
         }
 
-        .footer .initiative {
-            font-style: italic;
+        .after-flash {
+            background: #1a2e1a;
+            border-color: #2a4a2a;
+        }
+
+        .after-flash h2 {
+            color: #6abf69;
+        }
+
+        .after-flash ol {
+            padding-left: 20px;
+        }
+
+        .after-flash li {
+            padding: 6px 0;
+        }
+
+        .info-box {
+            font-size: 0.9em;
+            color: #a0a0b8;
+            background: #0f1a2e;
+            border-radius: 8px;
+            padding: 16px;
             margin-top: 16px;
         }
 
-        table {
-            border-spacing: 0;
+        .info-box code {
+            background: #2a2a4a;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 0.95em;
         }
 
-        td {
-            padding: 8px;
-            border-bottom: 1px solid #ccc;
+        a {
+            color: #53a8b6;
+            text-decoration: none;
         }
 
-        .radios li {
-            list-style: none;
-            line-height: 2em;
+        a:hover {
+            text-decoration: underline;
         }
 
-        @media (prefers-color-scheme: dark) {
-            body {
-                background-color: #333;
-                color: #fff;
-            }
+        .footer {
+            text-align: center;
+            margin-top: 40px;
+            padding-top: 24px;
+            border-top: 1px solid #2a2a4a;
+            font-size: 0.85em;
+            color: #666;
+        }
 
-            a {
-                color: #58a6ff;
-            }
+        .footer a {
+            color: #888;
+        }
+
+        .badge {
+            display: inline-block;
+            background: #0f3460;
+            color: #53a8b6;
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 0.8em;
+            font-weight: 600;
+            margin-bottom: 16px;
+        }
+
+        .debug-link {
+            text-align: center;
+            margin-top: 16px;
+            font-size: 0.85em;
+        }
+
+        .requirements {
+            font-size: 0.9em;
+            color: #a0a0b8;
+            margin-top: 12px;
+        }
+
+        .requirements strong {
+            color: #e0e0e0;
         }
     </style>
-    <script type="module" src="https://unpkg.com/esp-web-tools@8.0.1/dist/web/install-button.js?module"></script>
+    <script type="module"
+        src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"></script>
 </head>
 
 <body>
-    <div class="content">
-        <h1>Nightscout clock installer</h1>
-        <p>
-            This page is part of the <a href="https://github.com/ktomy/nightscout-clock/">Nightscout Clock</a> project.
-            It allows you to transform an Ulanzi TC001 programmable clock into a device showing blood sugar values
-            through <a href="https://github.com/nightscout/cgm-remote-monitor">Nightscout</a>
-        </p>
-        <p>
-            Here are the steps to install the firmware
-        </p>
-        <ul>
-            <li>Buy Ulanzi TC001 from <a
-                    href="https://www.ulanzi.com/products/ulanzi-pixel-smart-clock-2882?aff=1191">here</a>)</li>
-            <li>Turn on the device by pressing &lt; and &gt; buttons for 3 seconds</li>
-            <li>Connect the device to your computer using USB cable</li>
-            <li>Click the <b>CONNECT</b> button below</li>
-            <li>Follow the instructions</li>
-        </ul>
-        <p class="button-row" align="center">
-            <esp-web-install-button manifest="./manifest.json"></esp-web-install-button>
-        </p>
+    <div class="container">
+        <div class="hero">
+            <h1>Nightscout Clock</h1>
+            <p class="subtitle">Turn your Ulanzi TC001 into a CGM display</p>
+        </div>
 
+        <div class="card">
+            <h2>What you need</h2>
+            <ol class="steps">
+                <li>An <strong>Ulanzi TC001</strong> pixel clock (<a
+                        href="https://www.ulanzi.com/products/ulanzi-pixel-smart-clock-2882?aff=1191"
+                        target="_blank" rel="noopener">buy here</a>)</li>
+                <li>A <strong>USB-C cable</strong> connected to this computer</li>
+                <li><strong>Google Chrome</strong> or <strong>Microsoft Edge</strong> browser</li>
+            </ol>
+        </div>
+
+        <div class="card">
+            <h2>Install firmware</h2>
+            <ol class="steps">
+                <li>Power on the Ulanzi TC001 by holding the <strong>&lt;</strong> and
+                    <strong>&gt;</strong> buttons for 3 seconds</li>
+                <li>Connect it to this computer with a USB-C cable</li>
+                <li>Click the <strong>Install</strong> button below and select the serial port</li>
+            </ol>
+            <div class="install-box">
+                <p>Ready? Plug in your clock and click Install.</p>
+                <esp-web-install-button manifest="./manifest.json">
+                    <button slot="activate" style="
+                        background: #53a8b6;
+                        color: #fff;
+                        border: none;
+                        padding: 14px 40px;
+                        border-radius: 8px;
+                        font-size: 1.1em;
+                        font-weight: 600;
+                        cursor: pointer;
+                        transition: background 0.2s;
+                    ">Install Nightscout Clock</button>
+                    <span slot="unsupported">
+                        <div class="not-supported" style="display:block">
+                            Your browser does not support Web Serial.<br />
+                            Please open this page in <strong>Google Chrome</strong> or
+                            <strong>Microsoft Edge</strong> on a desktop computer.
+                        </div>
+                    </span>
+                </esp-web-install-button>
+            </div>
+        </div>
+
+        <div class="card after-flash">
+            <h2>After flashing</h2>
+            <ol>
+                <li>The clock will restart and show a setup screen</li>
+                <li>Connect to the <strong>NightscoutClock</strong> Wi-Fi network from your phone</li>
+                <li>A setup page will open automatically (or go to <code>192.168.4.1</code>)</li>
+                <li>Enter your Wi-Fi credentials and Nightscout URL</li>
+                <li>The clock will connect and start showing your glucose readings</li>
+            </ol>
+            <div class="info-box">
+                Need your Nightscout URL? It looks like
+                <code>https://yoursite.herokuapp.com</code> or
+                <code>https://yoursite.fly.dev</code>
+            </div>
+        </div>
+
+        <div class="debug-link">
+            <a href="./debug/">Developer? Try the debug build</a>
+        </div>
+
+        <div class="footer">
+            <p>
+                <a href="https://github.com/miqcie/nightscout-clock" target="_blank"
+                    rel="noopener">Source on GitHub</a>
+                &middot;
+                Based on <a href="https://github.com/ktomy/nightscout-clock" target="_blank"
+                    rel="noopener">ktomy/nightscout-clock</a>
+                &middot;
+                Powered by <a href="https://esphome.github.io/esp-web-tools/" target="_blank"
+                    rel="noopener">ESP Web Tools</a>
+            </p>
+        </div>
+    </div>
 </body>
 
 </html>

--- a/www/manifest.json
+++ b/www/manifest.json
@@ -1,31 +1,31 @@
 {
-    "name": "Nightscout clock",
-    "version": "0.29.0",
-    "builds": [
+  "name": "Nightscout Clock",
+  "version": "1.0.0",
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
         {
-            "chipFamily": "ESP32",
-            "parts": [
-                {
-                    "path": "https://ktomy.github.io/nightscout-clock/artifacts/bootloader.bin",
-                    "offset": 4096
-                },
-                {
-                    "path": "https://ktomy.github.io/nightscout-clock/artifacts/partitions.bin",
-                    "offset": 32768
-                },
-                {
-                    "path": "https://ktomy.github.io/nightscout-clock/artifacts/boot_app0.bin",
-                    "offset": 57344
-                },
-                {
-                    "path": "https://ktomy.github.io/nightscout-clock/artifacts/firmware.bin",
-                    "offset": 65536
-                },
-                {
-                    "path": "https://ktomy.github.io/nightscout-clock/artifacts/littlefs.bin",
-                    "offset": 2162688
-                }
-            ]
+          "path": "./artifacts/bootloader.bin",
+          "offset": 4096
+        },
+        {
+          "path": "./artifacts/partitions.bin",
+          "offset": 32768
+        },
+        {
+          "path": "./artifacts/boot_app0.bin",
+          "offset": 57344
+        },
+        {
+          "path": "./artifacts/firmware.bin",
+          "offset": 65536
+        },
+        {
+          "path": "./artifacts/littlefs.bin",
+          "offset": 2162688
         }
-    ]
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Redesigned `www/index.html` with a dark theme, numbered setup steps, and post-flash Wi-Fi/Nightscout configuration instructions -- parent-friendly, no technical jargon
- Updated `manifest.json` (release + debug) to use relative artifact paths so it works on any fork without hardcoded URLs
- Added `.github/workflows/pages.yml` that builds both release and debug firmware with PlatformIO, then deploys the `www/` directory to GitHub Pages (triggers on push to main, version tags, or manual dispatch)
- Upgraded ESP Web Tools from v8.0.1 to v10
- Updated debug flasher page to match the new visual design

## Setup required
After merging, enable GitHub Pages on the repo (Settings > Pages > Source: GitHub Actions). The workflow will handle the rest.

## Test plan
- [ ] Verify the workflow runs successfully on push to main
- [ ] Visit `miqcie.github.io/nightscout-clock` and confirm the flasher page loads
- [ ] Connect a Ulanzi TC001 via USB and test the install flow in Chrome
- [ ] Verify the debug build page at `/debug/` works independently
- [ ] Check that the "unsupported browser" message shows in Firefox/Safari

Closes #9

Generated with [Claude Code](https://claude.com/claude-code)