### PR TITLE
fix: rename interval_type typo and remove stale setup TODO

### DIFF
--- a/src/BGDisplayFaceGraphBase.cpp
+++ b/src/BGDisplayFaceGraphBase.cpp
@@ -70,13 +70,13 @@ void BGDisplayFaceGraphBase::showGraph(
     GlucoseInterval normalInterval = GlucoseInterval();
 
     for (const GlucoseInterval& interval : intervals.intervals) {
-        if (interval.intarval_type == BG_LEVEL::NORMAL) {
+        if (interval.interval_type == BG_LEVEL::NORMAL) {
             normalInterval = interval;
             break;
         }
     }
 
-    if (normalInterval.intarval_type == BG_LEVEL::INVALID) {
+    if (normalInterval.interval_type == BG_LEVEL::INVALID) {
         DisplayManager.showFatalError("No normal interval present, please set up");
     }
 

--- a/src/BGDisplayManager.cpp
+++ b/src/BGDisplayManager.cpp
@@ -20,7 +20,6 @@ BGDisplayManager_& bgDisplayManager = bgDisplayManager.getInstance();
 
 void BGDisplayManager_::setup() {
     glucoseIntervals = GlucoseIntervals();
-    /// TODO: Add urgent values to settings
 
     glucoseIntervals.addInterval(1, SettingsManager.settings.bg_low_urgent_limit, BG_LEVEL::URGENT_LOW);
     glucoseIntervals.addInterval(

--- a/src/BGDisplayManager.h
+++ b/src/BGDisplayManager.h
@@ -21,7 +21,7 @@
 struct GlucoseInterval {
     int low_boundary;
     int high_boundary;
-    BG_LEVEL intarval_type;
+    BG_LEVEL interval_type;
 };
 
 struct GlucoseIntervals {
@@ -33,7 +33,7 @@ struct GlucoseIntervals {
     BG_LEVEL getBGLevel(int value) {
         for (const GlucoseInterval& interval : intervals) {
             if (value >= interval.low_boundary && value <= interval.high_boundary) {
-                return interval.intarval_type;
+                return interval.interval_type;
             }
         }
         return BG_LEVEL::INVALID;  // Default to INVALID if not found in any interval
@@ -44,7 +44,7 @@ struct GlucoseIntervals {
         for (const GlucoseInterval& interval : intervals) {
             ss += "  Low: " + String(interval.low_boundary) +
                   ", High: " + String(interval.high_boundary) + ", Level: ";
-            switch (interval.intarval_type) {
+            switch (interval.interval_type) {
                 case BG_LEVEL::URGENT_HIGH:
                     ss += "URGENT_HIGH";
                     break;


### PR DESCRIPTION
## What changed
- Renamed `intarval_type` -> `interval_type` in `GlucoseInterval` and all references
- Removed stale TODO in `BGDisplayManager::setup()` since urgent limits are already loaded from settings

## Why
This addresses issue #32 and keeps the interval naming consistent/readable across graph and manager code.

Closes #32